### PR TITLE
Remove zero width chars from message

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -294,21 +294,17 @@ client.on('messageCreate', async (message) => {
 
   // I guess we could start out just by scanning each character of
   // the message and seeing if it's a number
-  // scan messages for zero-width characters and ignore them
-  for (let pos = 0; pos < message.content.length; pos++) {
-    for (let zeroWidthChar of zeroWidthCharacters) {
-        if (message.content[pos] === zeroWidthChar) {
-            console.log('Zero-width character detected. Ignoring message.');
-            return;
-        }
-    }
-
-    if (!numberRegex.test(message.content[pos])) {
-      return; // it's not just a number
-    }
+  // scan messages for zero-width characters and remove them
+  let sanitisedMessageContent = message.content;
+  for (let zeroWidthChar of zeroWidthCharacters) {
+    sanitisedMessageContent = sanitisedMessageContent.replace(zeroWidthChar, '');
   }
 
-  if (message.content !== counter.toString()) {
+  if (!numberRegex.test(sanitisedMessageContent)) {
+      return; // it's not just a number
+  }
+
+  if (sanitisedMessageContent !== counter.toString()) {
     // remove the user from the channel
     let members = message.guild.members;
     let user = members.resolve(message.author);


### PR DESCRIPTION
This PR sanitises the message by removing all zero width characters from it.

This is less confusing for users as they do not see zero width characters.
If we simply ignore messages with zero width characters, users may be deceived by other users.

For example, let's say the count is currently `0`, and user `A` and user `B` are counting:
```
A: 1
B: 2
A: 3&zwnj;
B: 4
```

In the above scenario, B would be out.

This change will strip the `&zwnj;` character from `A`'s message and increase the count to 3.