### PR TITLE
Remove bot token warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "discord.js": "^13.8.1",
-                "discord.js-slasher": "^0.4.0",
+                "discord.js-slasher": "^0.4.1",
                 "dotenv": "^16.0.1"
             },
             "devDependencies": {
@@ -218,9 +218,9 @@
             }
         },
         "node_modules/discord.js-slasher": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/discord.js-slasher/-/discord.js-slasher-0.4.0.tgz",
-            "integrity": "sha512-I8v4tLzDWlqYfQbcwFf5tvIIc6eO/hGmIAmGrv2vRqy2uuEH/LYGnpZSbr4BZR47oZV+0eysYJpL/gaNKJB2sw==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/discord.js-slasher/-/discord.js-slasher-0.4.1.tgz",
+            "integrity": "sha512-175Kqnr7Yv2DVGayBM3g02k8veLncEbkUsUGWJq/ybrzfG1pKB+xnp/DM2f4tsezAVcOoruK7+9FEAv5aqNfBw==",
             "dependencies": {
                 "@discordjs/rest": "^0.1.0-canary.0",
                 "ansi-colors": "^4.1.1",
@@ -534,9 +534,9 @@
             }
         },
         "discord.js-slasher": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/discord.js-slasher/-/discord.js-slasher-0.4.0.tgz",
-            "integrity": "sha512-I8v4tLzDWlqYfQbcwFf5tvIIc6eO/hGmIAmGrv2vRqy2uuEH/LYGnpZSbr4BZR47oZV+0eysYJpL/gaNKJB2sw==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/discord.js-slasher/-/discord.js-slasher-0.4.1.tgz",
+            "integrity": "sha512-175Kqnr7Yv2DVGayBM3g02k8veLncEbkUsUGWJq/ybrzfG1pKB+xnp/DM2f4tsezAVcOoruK7+9FEAv5aqNfBw==",
             "requires": {
                 "@discordjs/rest": "^0.1.0-canary.0",
                 "ansi-colors": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "homepage": "https://github.com/WilliamAtUni/macs-counting-bot.git#readme",
     "dependencies": {
         "discord.js": "^13.8.1",
-        "discord.js-slasher": "^0.4.0",
+        "discord.js-slasher": "^0.4.1",
         "dotenv": "^16.0.1"
     },
     "devDependencies": {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -294,7 +294,4 @@ function loadData(file: string, init: object) {
   return init;
 }
 
-// TODO: delete the 'process.env.TOKEN' part once Slasher bug is fixed
-// see: https://github.com/Romejanic/slasher/issues/11
-// that will stop the token related warnings being printed
-client.login(process.env.TOKEN);
+client.login();


### PR DESCRIPTION
Bumps to the latest version of Slasher which fixes a bug related to token handling. This allows some code to be fixed and for the annoying token related console warnings to go away.

**Before**
```sh
> macs-counting-bot@1.0.0 start
> node -r dotenv/config ./out/bot.js

Could not find bot token in client options or auth.json!
You must either provide a token or set useAuth to true!
Detected token being passed to login function! You should add it to the client options instead.
Slasher#7580 is ready
```

**After**
```sh
> macs-counting-bot@1.0.0 start
> node -r dotenv/config ./out/bot.js

Slasher#7580 is ready
```

Will require you to reinstall your modules to get Slasher up to date. Shouldn't be an issue if you're using docker to deploy it though.